### PR TITLE
issue#57: 错别字更正，'保存上传保存的目录存在' --> '确保上传保存的目录存在'

### DIFF
--- a/examples/basic-practices/micro-api/proxy/README.md
+++ b/examples/basic-practices/micro-api/proxy/README.md
@@ -38,4 +38,4 @@ POST请求到 **/example/foo/bar**会调用**go.micro.api.example**的 **/exampl
 
 ### 示例三 文件上传 /example/foo/upload
 
-我们可以请求`http://localhost:8080/example/foo/upload`，获取上传页面，选择适当的文件上传，测试上传功能。为了方便和直观，请保存上传保存的目录存在，且上传小文件
+我们可以请求`http://localhost:8080/example/foo/upload`，获取上传页面，选择适当的文件上传，测试上传功能。为了方便和直观，请确保上传保存的目录存在，且上传小文件


### PR DESCRIPTION
错别字更正，'保存上传保存的目录存在' --> '确保上传保存的目录存在'