### PR TITLE
修正examples指向page not found，改成相对链接

### DIFF
--- a/microservice-in-micro/README.md
+++ b/microservice-in-micro/README.md
@@ -121,7 +121,7 @@ Golang，gRPC，Mysql，Redis，Docker，K8s，Go-micro/Micro
 
 朋友，请加入[slack](http://slack.micro.mu/)，进入**中国区**Channel沟通。
 
-[examples]: https://github.com/micro-in-cn/tutorials/examples
+[examples]: /examples
 [gRPC]: https://grpc.io/
 
 [第一章]: ./part1


### PR DESCRIPTION
可能是当项目里有多分支的时候，https://github.com/micro-in-cn/tutorials/examples 就不能指向正确的页面。上次也有一个这样的问题。